### PR TITLE
Deploy using gh-pages branch

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -37,13 +37,25 @@ jobs:
       - name: Install Node.js dependencies with NPM
         run: "npm ci"
 
+      - name: Get URL of pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: url
+        run: |
+          {
+            echo "URL<<EOF"
+            gh api "repos/$GITHUB_REPOSITORY/pages" --jq ".html_url"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build with Hugo
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
           HUGO_ENVIRONMENT: production
           TZ: Europe/Berlin
         run: |
-          npm run build
+          npm run build -- \
+            --baseURL "${{ steps.url.outputs.URL }}"
                
       - name: Deploy to pages
         uses: JamesIves/github-pages-deploy-action@v4.7.3

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -14,15 +14,13 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 # Default to bash
 defaults:
@@ -30,16 +28,13 @@ defaults:
     shell: bash
 
 jobs:
-  # Build job
-  build:
+  run:
+    name: Build and publish GitHub pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
-      - name: Install Node.js dependencies
+      - name: Install Node.js dependencies with NPM
         run: "npm ci"
 
       - name: Build with Hugo
@@ -48,22 +43,14 @@ jobs:
           HUGO_ENVIRONMENT: production
           TZ: Europe/Berlin
         run: |
-          npm run build -- \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"          
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+          npm run build
+               
+      - name: Deploy to pages
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:
-          path: ./public
+          folder: ./public
+          clean-exclude: pr-preview/
+          force: false
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,44 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: 
+    group: preview-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Deploy preview of PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+    
+      - name: Get URL of pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: url
+        run: |
+          {
+            echo "URL<<EOF"
+            gh api "repos/$GITHUB_REPOSITORY/pages" --jq ".html_url"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install and Build
+        if: github.event.action != 'closed' # You might want to skip the build if the PR has been closed
+        run: |
+          npm install
+          npm run build -- \
+            --baseURL "${{ steps.url.outputs.URL }}/pr-preview/pr-${{ github.event.number }}"
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./public/

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://example.org/
+baseURL: https://genius-itea.github.io/
 languageCode: en-us
 title: GENIUS
 


### PR DESCRIPTION
This will switch to page deployment using the `gh-branch` branch. This will allow for previews of PRs.

@otto-ifak, could you change to gh-branch deployment in the settings?
![grafik](https://github.com/user-attachments/assets/075caa6d-23da-4617-8ac4-d4906f99ab0c)

It is possible that you have to merge prior. 